### PR TITLE
Added option "-x secs" to include seconds when printing the time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,23 @@ Usage
 
 ```
 Usage:
-  sun [-ahirsw] [-o OFFSET] [+/-latitude +/-longitude]
+  sun [-ahilrsuvw] [-d YYYY-MM-DD] [-o OFFSET] [-x FLAG] [-- +/-latitude +/-longitude]
 
 Options:
   -a      Show all relevant times and exit
-  -l      Increased verbosity, enable log messages
   -h      This help text
   -i      Interactive mode
+  -l      Increased verbosity, enable log messages
   -r      Sunrise mode
   -s      Sunset mode
   -u      Use UTC everywhere, not local time
   -v      Show program version and exit
   -w      Wait until sunset or sunrise
+  -d ARG  Specific date, in "yyyy-mm-dd" format.
   -o ARG  Time offset to adjust wait, e.g. -o -30m
           maximum allowed offset: +/- 6h
+  -x ARG  Extra options:
+          -x secs  Show times with seconds.
 
 Bug report address: https://github.com/troglobit/sun/issues
 ```

--- a/sun.c
+++ b/sun.c
@@ -97,6 +97,17 @@ static void convert(double ut, int *h, int *m, int *s)
 
 	s_local = (int)(ut * 3600 + 0.5);
 
+	/* Bump the minute, and maybe the hour, if seconds is 60. */
+	if (s_local == 60) {
+		s_local = 0;
+		++*m;
+		if (*m == 60) {
+			++*h;
+			*m = 0;
+			/* Not sure how to handle *h == 24. */
+		}
+	}
+
 	if (s == NULL) {
 		/* Round to the nearest minute. */
 		if (s_local >= 30) {

--- a/sun.c
+++ b/sun.c
@@ -99,8 +99,14 @@ static void convert(double ut, int *h, int *m, int *s)
 
 	if (s == NULL) {
 		/* Round to the nearest minute. */
-		if (s_local >= 30)
+		if (s_local >= 30) {
 			++*m;
+			if (*m == 60) {
+				++*h;
+				*m = 0;
+				/* Not sure how to handle *h == 24. */
+			}
+		}
 	}
 	else
 		*s = s_local;


### PR DESCRIPTION
Added an option to show seconds when printing time values.

In "convert()", the creation of "*h" and "*m" were modified to help make sure "*s" was properly created.